### PR TITLE
add github links to https://metacpan.org/release/Lingua-Interset

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -61,3 +61,8 @@ changelog = Changes.txt
 allow_dirty_match = ^lib/
 commit_msg = Commit Changes and bump $VERSION
 [Git::Push]
+
+[MetaResources]
+homepage   = http://ufal.mff.cuni.cz/interset
+repository = https://github.com/dan-zeman/interset
+bugtracker = https://github.com/dan-zeman/interset/issues


### PR DESCRIPTION
See e.g. https://metacpan.org/release/Treex-Core for an example
how it will look like: there will be links to
- the github repo
- the github issues (instead of the default https://rt.cpan.org/Public/Dist/Display.html?Name=Lingua-Interset which no one uses)
- the web
